### PR TITLE
Evitar canvi de mida horitzontal del textarea

### DIFF
--- a/hyphen-softcatala.js
+++ b/hyphen-softcatala.js
@@ -58,15 +58,11 @@ String.prototype.isErraSensible = function() {
     return erraSensible.includes(s);
 }
 
-// Restore saved text
-const saved_text = localStorage.getItem("text");
-document.getElementById("text_to_hyphen").value = saved_text ?? '';
 
 onChangeFunction(); //first time
 
 function onChangeFunction() {
     var original_text = normalizeNFC(document.getElementById("text_to_hyphen").value.trim()).replace(/_/g, " ");
-    localStorage.setItem("text", original_text);
     var lc = original_text.lineCount();
     if (lc < 1) {
         document.getElementById("result").innerHTML = "";

--- a/hyphen-softcatala.js
+++ b/hyphen-softcatala.js
@@ -58,11 +58,15 @@ String.prototype.isErraSensible = function() {
     return erraSensible.includes(s);
 }
 
+// Restore saved text
+const saved_text = localStorage.getItem("text");
+document.getElementById("text_to_hyphen").value = saved_text ?? '';
 
 onChangeFunction(); //first time
 
 function onChangeFunction() {
     var original_text = normalizeNFC(document.getElementById("text_to_hyphen").value.trim()).replace(/_/g, " ");
+    localStorage.setItem("text", original_text);
     var lc = original_text.lineCount();
     if (lc < 1) {
         document.getElementById("result").innerHTML = "";

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
  </style>
  <body>
    <h1>Separador i comptador de síl·labes</h1>
-   <textarea rows="6" cols="80" placeholder="Introduïu una paraula, una frase o un poema" id="text_to_hyphen" oninput="onChangeFunction()"></textarea>
+   <textarea style="resize: vertical;" rows="6" cols="80" placeholder="Introduïu una paraula, una frase o un poema" id="text_to_hyphen" oninput="onChangeFunction()"></textarea>
 
         <br/>
         <br/>


### PR DESCRIPTION
Si permetem el canvi de mida tant horitzontal com vertical, es pot fer que el textarea cobreixi part de la resta de la pàgina com es pot veure a la imatge.

![image](https://user-images.githubusercontent.com/77280741/205974861-1a65bd3d-09be-449c-a67c-06622bbe3b6c.png)

Afegir l'estil `resize: vertical;` permet a l'usuari fer l'input tan gran com vulgui, però només verticalment.

_(Si us plau ignoreu els últims dos commits, m'he equivocat de branca)_