### PR TITLE
Recuperar text de l'última sessió amb localStorage

### DIFF
--- a/hyphen-softcatala.js
+++ b/hyphen-softcatala.js
@@ -58,11 +58,15 @@ String.prototype.isErraSensible = function() {
     return erraSensible.includes(s);
 }
 
+// Restore saved text
+const saved_text = localStorage.getItem("text");
+document.getElementById("text_to_hyphen").value = saved_text ?? '';
 
 onChangeFunction(); //first time
 
 function onChangeFunction() {
     var original_text = normalizeNFC(document.getElementById("text_to_hyphen").value.trim()).replace(/_/g, " ");
+    localStorage.setItem("text", original_text);
     var lc = original_text.lineCount();
     if (lc < 1) {
         document.getElementById("result").innerHTML = "";


### PR DESCRIPTION
L'altre dia vaig utilitzar el separador de síl·labes per escriure un poema i vaig tenir la mala sort de que l'ordinador se'm va reiniciar sol. Malauradament, no vaig poder recuperar-lo.

He pensat que, per evitar accidents com aquest, dins la funció `onChangeFunction()` podríem desar el text al localStorage i, en carregar la pàgina, recuperar-lo.

Només són 5 línies de codi més i crec que realment pot ser útil per als usuaris.